### PR TITLE
feat: implement rule-based newline character conversion

### DIFF
--- a/src/paratranz/converter/index.ts
+++ b/src/paratranz/converter/index.ts
@@ -6,7 +6,7 @@ import type { File, ParatranzFile, StringItem, TranslationFile } from '~/paratra
 import chalk from 'chalk'
 import { log } from '~/log'
 import { FileExtraSchema } from '~/paratranz/types.ts'
-import { NewlineRuleManager } from './rules.ts'
+import { NewlineRules } from './rules.ts'
 
 export class Converter {
   constructor(
@@ -36,7 +36,7 @@ export class Converter {
     const sortedProperties = Object.entries(fileExtra.properties)
       .sort(([, a], [, b]) => a.start - b.start)
 
-    const newlineRule = NewlineRuleManager.getRule(fileExtra.targetRelpath)
+    const newlineRule = NewlineRules.find(fileExtra.targetRelpath)
 
     const result = []
     let lastEnd = 0
@@ -85,7 +85,7 @@ export class Converter {
       translation: '',
     }))
 
-    const newlineRule = NewlineRuleManager.getRule(targetRelpath)
+    const newlineRule = NewlineRules.find(targetRelpath)
     if (newlineRule) {
       stringItems.forEach((item) => {
         item.original = newlineRule.toParatranz(item.original)

--- a/src/paratranz/converter/index.ts
+++ b/src/paratranz/converter/index.ts
@@ -63,11 +63,8 @@ export class Converter {
     result.push(...originalContent.slice(lastEnd))
 
     let resultString = result.join('')
-    if (fileExtra.targetRelpath.startsWith('scripts/')) {
-      resultString = resultString.replace(
-        'val _I18N_Lang = "en_US";',
-        `val _I18N_Lang = "${this.targetLang}";`,
-      )
+    if (newlineRule?.postProcess) {
+      resultString = newlineRule.postProcess(resultString, this.targetLang)
     }
 
     return {

--- a/src/paratranz/converter/index.ts
+++ b/src/paratranz/converter/index.ts
@@ -6,7 +6,7 @@ import type { File, ParatranzFile, StringItem, TranslationFile } from '~/paratra
 import chalk from 'chalk'
 import { log } from '~/log'
 import { FileExtraSchema } from '~/paratranz/types.ts'
-import { toUnicode } from '~/utils/unicode.ts'
+import { NewlineRuleManager } from './rules.ts'
 
 export class Converter {
   constructor(
@@ -36,7 +36,8 @@ export class Converter {
     const sortedProperties = Object.entries(fileExtra.properties)
       .sort(([, a], [, b]) => a.start - b.start)
 
-    const isScript = fileExtra.targetRelpath.startsWith('scripts/')
+    const newlineRule = NewlineRuleManager.getRule(fileExtra.targetRelpath)
+
     const result = []
     let lastEnd = 0
 
@@ -49,11 +50,8 @@ export class Converter {
 
       let translation = stringItem.translation
       if (translation) {
-        if (isScript) {
-          // Convert each part separated by <BR> to unicode, then join back with <BR>
-          translation = translation.split('<BR>')
-            .map(part => toUnicode(part))
-            .join('<BR>')
+        if (newlineRule) {
+          translation = newlineRule.fromParatranz(translation)
         }
         result.push(...translation)
       }
@@ -65,7 +63,7 @@ export class Converter {
     result.push(...originalContent.slice(lastEnd))
 
     let resultString = result.join('')
-    if (isScript) {
+    if (fileExtra.targetRelpath.startsWith('scripts/')) {
       resultString = resultString.replace(
         'val _I18N_Lang = "en_US";',
         `val _I18N_Lang = "${this.targetLang}";`,
@@ -89,6 +87,13 @@ export class Converter {
       context: p.full,
       translation: '',
     }))
+
+    const newlineRule = NewlineRuleManager.getRule(targetRelpath)
+    if (newlineRule) {
+      stringItems.forEach((item) => {
+        item.original = newlineRule.toParatranz(item.original)
+      })
+    }
 
     // Try to merge old translations
     const remoteFileId = await this.client.findFileIdByName(fileName)

--- a/src/paratranz/converter/rules.ts
+++ b/src/paratranz/converter/rules.ts
@@ -1,3 +1,4 @@
+import type { Language } from '~/filetypes/language.ts'
 import { dirname } from 'node:path'
 import * as settings from '~/settings.ts'
 import { toUnicode } from '~/utils/unicode.ts'
@@ -10,7 +11,7 @@ export interface NewlineRule {
   /** Conversion when exporting from Paratranz (\n -> placeholder) */
   fromParatranz: (text: string) => string
   /** Optional post-processing for the entire file content after assembly */
-  postProcess?: (text: string, targetLang: string) => string
+  postProcess?: (text: string, targetLang: Language) => string
 }
 
 export class ScriptNewlineRule implements NewlineRule {
@@ -29,7 +30,7 @@ export class ScriptNewlineRule implements NewlineRule {
       .join('<BR>')
   }
 
-  postProcess = (text: string, targetLang: string): string => {
+  postProcess = (text: string, targetLang: Language): string => {
     return text.replace(
       'val _I18N_Lang = "en_US";',
       `val _I18N_Lang = "${targetLang}";`,

--- a/src/paratranz/converter/rules.ts
+++ b/src/paratranz/converter/rules.ts
@@ -1,0 +1,69 @@
+import { dirname } from 'node:path'
+import * as settings from '~/settings.ts'
+import { toUnicode } from '~/utils/unicode.ts'
+
+export interface NewlineRule {
+  /** 匹配文件路径 */
+  match: (relpath: string) => boolean
+  /** 导入 Paratranz 时的转换 (占位符 -> \n) */
+  toParatranz: (text: string) => string
+  /** 从 Paratranz 导出时的转换 (\n -> 占位符) */
+  fromParatranz: (text: string) => string
+}
+
+export class ScriptNewlineRule implements NewlineRule {
+  match(relpath: string): boolean {
+    return relpath.startsWith('scripts/')
+  }
+
+  toParatranz(text: string): string {
+    return text.replaceAll('<BR>', '\n')
+  }
+
+  fromParatranz(text: string): string {
+    // Convert each part separated by \n to unicode, then join back with <BR>
+    return text.split('\n')
+      .map(part => toUnicode(part))
+      .join('<BR>')
+  }
+}
+
+export class QuestNewlineRule implements NewlineRule {
+  match(relpath: string): boolean {
+    return relpath.startsWith(dirname(settings.DEFAULT_QUESTS_LANG_TARGET_REL_PATH))
+  }
+
+  toParatranz(text: string): string {
+    return text.replaceAll('%n', '\n')
+  }
+
+  fromParatranz(text: string): string {
+    return text.replaceAll('\n', '%n')
+  }
+}
+
+export class GTLangNewlineRule implements NewlineRule {
+  match(relpath: string): boolean {
+    return relpath.endsWith('GregTech.lang')
+  }
+
+  toParatranz(text: string): string {
+    return text.replaceAll('<BR>', '\n')
+  }
+
+  fromParatranz(text: string): string {
+    return text.replaceAll('\n', '<BR>')
+  }
+}
+
+export class NewlineRuleManager {
+  private static rules: NewlineRule[] = [
+    new ScriptNewlineRule(),
+    new QuestNewlineRule(),
+    new GTLangNewlineRule(),
+  ]
+
+  static getRule(relpath: string): NewlineRule | undefined {
+    return this.rules.find(rule => rule.match(relpath))
+  }
+}

--- a/src/paratranz/converter/rules.ts
+++ b/src/paratranz/converter/rules.ts
@@ -20,7 +20,7 @@ export class ScriptNewlineRule implements NewlineRule {
   }
 
   toParatranz = (text: string): string => {
-    return text.replaceAll('<BR>', '\n')
+    return text.replaceAll('<BR>', '\n').replaceAll('<br>', '\n')
   }
 
   fromParatranz = (text: string): string => {
@@ -58,7 +58,7 @@ export class GTLangNewlineRule implements NewlineRule {
   }
 
   toParatranz = (text: string): string => {
-    return text.replaceAll('<BR>', '\n')
+    return text.replaceAll('<BR>', '\n').replaceAll('<br>', '\n')
   }
 
   fromParatranz = (text: string): string => {

--- a/src/paratranz/converter/rules.ts
+++ b/src/paratranz/converter/rules.ts
@@ -3,55 +3,64 @@ import * as settings from '~/settings.ts'
 import { toUnicode } from '~/utils/unicode.ts'
 
 export interface NewlineRule {
-  /** 匹配文件路径 */
+  /** Match the file path */
   match: (relpath: string) => boolean
-  /** 导入 Paratranz 时的转换 (占位符 -> \n) */
+  /** Conversion when importing to Paratranz (placeholder -> \n) */
   toParatranz: (text: string) => string
-  /** 从 Paratranz 导出时的转换 (\n -> 占位符) */
+  /** Conversion when exporting from Paratranz (\n -> placeholder) */
   fromParatranz: (text: string) => string
+  /** Optional post-processing for the entire file content after assembly */
+  postProcess?: (text: string, targetLang: string) => string
 }
 
 export class ScriptNewlineRule implements NewlineRule {
-  match(relpath: string): boolean {
+  match = (relpath: string): boolean => {
     return relpath.startsWith('scripts/')
   }
 
-  toParatranz(text: string): string {
+  toParatranz = (text: string): string => {
     return text.replaceAll('<BR>', '\n')
   }
 
-  fromParatranz(text: string): string {
+  fromParatranz = (text: string): string => {
     // Convert each part separated by \n to unicode, then join back with <BR>
     return text.split('\n')
       .map(part => toUnicode(part))
       .join('<BR>')
   }
+
+  postProcess = (text: string, targetLang: string): string => {
+    return text.replace(
+      'val _I18N_Lang = "en_US";',
+      `val _I18N_Lang = "${targetLang}";`,
+    )
+  }
 }
 
 export class QuestNewlineRule implements NewlineRule {
-  match(relpath: string): boolean {
+  match = (relpath: string): boolean => {
     return relpath.startsWith(dirname(settings.DEFAULT_QUESTS_LANG_TARGET_REL_PATH))
   }
 
-  toParatranz(text: string): string {
+  toParatranz = (text: string): string => {
     return text.replaceAll('%n', '\n')
   }
 
-  fromParatranz(text: string): string {
+  fromParatranz = (text: string): string => {
     return text.replaceAll('\n', '%n')
   }
 }
 
 export class GTLangNewlineRule implements NewlineRule {
-  match(relpath: string): boolean {
+  match = (relpath: string): boolean => {
     return relpath.endsWith('GregTech.lang')
   }
 
-  toParatranz(text: string): string {
+  toParatranz = (text: string): string => {
     return text.replaceAll('<BR>', '\n')
   }
 
-  fromParatranz(text: string): string {
+  fromParatranz = (text: string): string => {
     return text.replaceAll('\n', '<BR>')
   }
 }

--- a/src/paratranz/converter/rules.ts
+++ b/src/paratranz/converter/rules.ts
@@ -66,14 +66,14 @@ export class GTLangNewlineRule implements NewlineRule {
   }
 }
 
-export class NewlineRuleManager {
-  private static rules: NewlineRule[] = [
+export class NewlineRules {
+  private static readonly all: NewlineRule[] = [
     new ScriptNewlineRule(),
     new QuestNewlineRule(),
     new GTLangNewlineRule(),
   ]
 
-  static getRule(relpath: string): NewlineRule | undefined {
-    return this.rules.find(rule => rule.match(relpath))
+  static find(relpath: string): NewlineRule | undefined {
+    return this.all.find(rule => rule.match(relpath))
   }
 }


### PR DESCRIPTION
## 业务背景与需求 (Business Context)
GTNH 项目中存在多种非标准的换行占位符（如 `<BR>`, `%n`），这给翻译工作流带来了以下挑战：
1. **可读性差**：翻译人员在 Paratranz 界面看到的是原始占位符，无法预览实际排版效果。
2. **易出错**：手动编辑占位符容易导致拼写错误或格式缺失，进而在游戏内引发崩溃或显示问题。
3. **维护困难**：不同文件类型的换行规范不一（如 Scripts 使用 `<BR>`, Quests 使用 `%n`），硬编码处理难以维护。

## 主要更改 (Key Changes)
本 PR 引入了一套基于**规则模式 (Rule Pattern)** 的换行符转换机制：
- **透明转换**：在同步至 Paratranz 时，自动将文件特定的占位符转换为真实的换行符 `\n`。
- **还原导出**：在生成游戏文件时，根据文件类型将 `\n` 精确还原回原始占位符。
- **结构保护**：转换仅作用于 Paratranz 词条内容，**不修改**底层的 `fileExtra.original` 模板和偏移量元数据，确保生成的磁盘文件与原始结构完全一致。

## 技术实现 (Technical Implementation)
- **规则引擎设计**：通过 `NewlineRule` 接口解耦不同文件的转换逻辑。
- **支持范围扩展**：
  - `scripts/` (处理 `<BR>` 及 Unicode 转义)
  - `betterquesting/lang/` (处理 `%n`)
  - `GregTech.lang` (处理 `<BR>`)