### PR TITLE
fix: refine line break form detection and ParaTranz round-trip

### DIFF
--- a/src/paratranz/converter/index.ts
+++ b/src/paratranz/converter/index.ts
@@ -9,7 +9,7 @@ import { FileExtraSchema } from '~/paratranz/types.ts'
 import {
   appendLineBreakFormToContext,
   collectLineBreakFormsFromContexts,
-  collectLineBreakFormsFromOriginal,
+  lineBreakOptionsForKey,
   mergeLineBreakFileForms,
   normalizeLineBreaks,
   resolveLineBreakForm,
@@ -49,7 +49,7 @@ export class Converter {
     const lineBreakRule = LineBreakRules.find(targetRelpath)
     const lineBreakForms = mergeLineBreakFileForms(
       collectLineBreakFormsFromContexts(stringItems),
-      collectLineBreakFormsFromOriginal(fileExtra.original, fileExtra.properties),
+      { entries: {} },
     )
 
     const result = []
@@ -90,12 +90,15 @@ export class Converter {
   async toParatranzFile(file: Filetype): Promise<ParatranzFile> {
     const targetRelpath = file.getTargetLanguageRelpath(this.targetLang)
     const fileName = `${targetRelpath}.json`
+    const lineBreakRule = LineBreakRules.find(targetRelpath)
 
     const stringItems: StringItem[] = Object.values(file.properties).map((p) => {
-      const lineBreakForm = sniffLineBreak(p.value)
+      const lineBreakOptions = lineBreakOptionsForKey(p.key)
+      const lineBreakForm = sniffLineBreak(p.value, lineBreakOptions)
+        ?? resolveLineBreakForm({ entries: {} }, p.key, lineBreakRule?.fallbackForm)
       return {
         key: p.key,
-        original: normalizeLineBreaks(p.value),
+        original: normalizeLineBreaks(p.value, lineBreakOptions),
         ...(lineBreakForm ? { context: appendLineBreakFormToContext('', lineBreakForm) } : {}),
         translation: '',
       }
@@ -138,7 +141,8 @@ export class Converter {
     // Merge old translations if they match original text
     for (const s of newItems) {
       const old = oldStringsMap.get(s.key)
-      if (old && normalizeLineBreaks(old.original) === normalizeLineBreaks(s.original) && old.translation) {
+      const lineBreakOptions = lineBreakOptionsForKey(s.key)
+      if (old && normalizeLineBreaks(old.original, lineBreakOptions) === normalizeLineBreaks(s.original, lineBreakOptions) && old.translation) {
         if (s.translation !== old.translation) {
           s.translation = old.translation
           s.stage = old.stage

--- a/src/paratranz/converter/line-breaks.ts
+++ b/src/paratranz/converter/line-breaks.ts
@@ -2,19 +2,30 @@ export const LINE_BREAK_FORMS = ['<BR>', '<br>', '[br]', '\\\\n', '\\n', '%n', '
 export type LineBreakForm = typeof LINE_BREAK_FORMS[number]
 
 const LINE_BREAK_CONTEXT_PREFIX = '@gtnh-line-break-form='
+const PERCENT_N_LINE_BREAK_FORM = '%n' satisfies LineBreakForm
+const SLASH_N_LINE_BREAK_FORM = '\\n' satisfies LineBreakForm
+const BETTER_QUESTING_QUEST_KEY = 'betterquesting.quest'
 const LINE_BREAK_PLACEHOLDER_FORMS = LINE_BREAK_FORMS.filter(
   (form): form is Exclude<LineBreakForm, 'LF'> => form !== 'LF',
 )
 const LINE_BREAK_FORM_SET = new Set<LineBreakForm>(LINE_BREAK_FORMS)
+const LINE_BREAK_CONTEXT_VALUES: Record<LineBreakForm, string> = {
+  '<BR>': '<BR>-UP',
+  '<br>': '<br>',
+  '[br]': '[br]',
+  '\\\\n': '\\\\n',
+  '\\n': '\\n',
+  '%n': '%n',
+  'LF': 'LF',
+}
+
+export interface LineBreakOptions {
+  allowPercentN?: boolean
+}
 
 export interface LineBreakFileForms {
   default?: LineBreakForm
   entries: Record<string, LineBreakForm>
-}
-
-interface RangeProperty {
-  start: number
-  end: number
 }
 
 interface ContextProperty {
@@ -22,9 +33,24 @@ interface ContextProperty {
   context?: string | null
 }
 
-export function sniffLineBreak(value: string): LineBreakForm | undefined {
-  for (const form of LINE_BREAK_PLACEHOLDER_FORMS) {
-    if (value.includes(form))
+export function lineBreakOptionsForKey(key: string): LineBreakOptions {
+  return {
+    allowPercentN: isBetterQuestingQuestKey(key),
+  }
+}
+
+export function isBetterQuestingQuestKey(key: string): boolean {
+  return key.toLowerCase().includes(BETTER_QUESTING_QUEST_KEY)
+}
+
+export function sniffLineBreak(value: string, options: LineBreakOptions = {}): LineBreakForm | undefined {
+  for (const form of placeholderForms(options)) {
+    const hasForm = form === PERCENT_N_LINE_BREAK_FORM
+      ? hasUnescapedPercentN(value)
+      : form === SLASH_N_LINE_BREAK_FORM
+        ? hasUnescapedSlashN(value)
+        : value.includes(form)
+    if (hasForm)
       return form
   }
   if (value.includes('\n'))
@@ -32,10 +58,15 @@ export function sniffLineBreak(value: string): LineBreakForm | undefined {
   return undefined
 }
 
-export function normalizeLineBreaks(value: string): string {
+export function normalizeLineBreaks(value: string, options: LineBreakOptions = {}): string {
   let normalized = value
-  for (const form of LINE_BREAK_PLACEHOLDER_FORMS)
-    normalized = normalized.replaceAll(form, '\n')
+  for (const form of placeholderForms(options)) {
+    normalized = form === PERCENT_N_LINE_BREAK_FORM
+      ? replaceUnescapedPercentN(normalized)
+      : form === SLASH_N_LINE_BREAK_FORM
+        ? replaceUnescapedSlashN(normalized)
+        : normalized.replaceAll(form, '\n')
+  }
   return normalized
 }
 
@@ -49,28 +80,16 @@ export function appendLineBreakFormToContext(context: string, form: LineBreakFor
   if (!form)
     return context
   const strippedContext = stripLineBreakFormFromContext(context)
-  const marker = `${LINE_BREAK_CONTEXT_PREFIX}${form}`
+  const marker = `${LINE_BREAK_CONTEXT_PREFIX}${LINE_BREAK_CONTEXT_VALUES[form]}`
   return strippedContext ? `${strippedContext}\n${marker}` : marker
 }
 
-export function collectLineBreakFormsFromOriginal(
-  original: string,
-  properties: Record<string, RangeProperty>,
+export function collectLineBreakFormsFromContexts(
+  items: readonly ContextProperty[],
 ): LineBreakFileForms {
-  const chars = [...original]
-  const entries: Record<string, LineBreakForm> = {}
-  for (const [key, prop] of Object.entries(properties)) {
-    const form = sniffLineBreak(chars.slice(prop.start, prop.end).join(''))
-    if (form)
-      entries[key] = form
-  }
-  return withDefault(entries)
-}
-
-export function collectLineBreakFormsFromContexts(items: readonly ContextProperty[]): LineBreakFileForms {
   const entries: Record<string, LineBreakForm> = {}
   for (const item of items) {
-    const form = parseLineBreakFormFromContext(item.context)
+    const form = parseLineBreakFormFromContext(item.context, lineBreakOptionsForKey(item.key))
     if (form)
       entries[item.key] = form
   }
@@ -85,7 +104,9 @@ export function mergeLineBreakFileForms(
     ...fallback.entries,
     ...primary.entries,
   }
-  const defaultForm = primary.default ?? fallback.default ?? mostFrequentLineBreakForm(entries)
+  const defaultForm = primary.default
+    ?? fallback.default
+    ?? mostFrequentLineBreakForm(entries)
   return {
     ...(defaultForm ? { default: defaultForm } : {}),
     entries,
@@ -97,10 +118,14 @@ export function resolveLineBreakForm(
   key: string,
   fallback: LineBreakForm | undefined,
 ): LineBreakForm | undefined {
+  const options = lineBreakOptionsForKey(key)
   const normalizedKey = key.toLowerCase()
-  return forms.entries[key]
-    ?? (normalizedKey.includes('research_page') || normalizedKey.includes('research.page') ? '<BR>' : forms.default)
-    ?? fallback
+  return allowedLineBreakForm(forms.entries[key], options)
+    ?? (normalizedKey.includes('research_page') || normalizedKey.includes('research.page')
+      ? '<BR>'
+      : allowedLineBreakForm(forms.default, options))
+    ?? allowedLineBreakForm(fallback, options)
+    ?? (options.allowPercentN ? PERCENT_N_LINE_BREAK_FORM : undefined)
 }
 
 function withDefault(entries: Record<string, LineBreakForm>): LineBreakFileForms {
@@ -130,7 +155,10 @@ function isLineBreakForm(value: unknown): value is LineBreakForm {
   return typeof value === 'string' && LINE_BREAK_FORM_SET.has(value as LineBreakForm)
 }
 
-function parseLineBreakFormFromContext(context: string | null | undefined): LineBreakForm | undefined {
+function parseLineBreakFormFromContext(
+  context: string | null | undefined,
+  options: LineBreakOptions,
+): LineBreakForm | undefined {
   if (!context)
     return undefined
 
@@ -140,8 +168,8 @@ function parseLineBreakFormFromContext(context: string | null | undefined): Line
     if (!line.startsWith(LINE_BREAK_CONTEXT_PREFIX))
       continue
 
-    const form = line.slice(LINE_BREAK_CONTEXT_PREFIX.length).trim()
-    if (isLineBreakForm(form))
+    const form = decodeLineBreakContextValue(line.slice(LINE_BREAK_CONTEXT_PREFIX.length).trim())
+    if (form && allowedLineBreakForm(form, options))
       return form
   }
   return undefined
@@ -152,4 +180,88 @@ function stripLineBreakFormFromContext(context: string): string {
     .split(/\r?\n/)
     .filter(line => !line.trim().startsWith(LINE_BREAK_CONTEXT_PREFIX))
     .join('\n')
+}
+
+function placeholderForms(options: LineBreakOptions): readonly Exclude<LineBreakForm, 'LF'>[] {
+  return LINE_BREAK_PLACEHOLDER_FORMS.filter(form => allowedLineBreakForm(form, options))
+}
+
+function allowedLineBreakForm(
+  form: LineBreakForm | undefined,
+  options: LineBreakOptions,
+): LineBreakForm | undefined {
+  if (form === PERCENT_N_LINE_BREAK_FORM && !options.allowPercentN)
+    return undefined
+  return form
+}
+
+function decodeLineBreakContextValue(value: string): LineBreakForm | undefined {
+  if (value === '<BR>-UP' || value === '<br>-UP')
+    return '<BR>'
+
+  for (const [form, contextValue] of Object.entries(LINE_BREAK_CONTEXT_VALUES)) {
+    if (value === contextValue)
+      return form as LineBreakForm
+  }
+  return isLineBreakForm(value) ? value : undefined
+}
+
+function hasUnescapedPercentN(value: string): boolean {
+  for (let i = 0; i < value.length - 1; i++) {
+    if (value[i] === '%' && value[i + 1] === 'n' && isUnescapedPercentNAt(value, i))
+      return true
+  }
+  return false
+}
+
+function replaceUnescapedPercentN(value: string): string {
+  let result = ''
+  let i = 0
+  while (i < value.length) {
+    if (i < value.length - 1 && value[i] === '%' && value[i + 1] === 'n' && isUnescapedPercentNAt(value, i)) {
+      result += '\n'
+      i += 2
+      continue
+    }
+    result += value[i]
+    i++
+  }
+  return result
+}
+
+function isUnescapedPercentNAt(value: string, index: number): boolean {
+  let consecutivePercents = 0
+  for (let i = index - 1; i >= 0 && value[i] === '%'; i--)
+    consecutivePercents++
+  return consecutivePercents % 2 === 0
+}
+
+function hasUnescapedSlashN(value: string): boolean {
+  for (let i = 0; i < value.length - 1; i++) {
+    if (value[i] === '\\' && value[i + 1] === 'n' && isUnescapedSlashNAt(value, i))
+      return true
+  }
+  return false
+}
+
+function replaceUnescapedSlashN(value: string): string {
+  let result = ''
+  let i = 0
+  while (i < value.length) {
+    if (i < value.length - 1 && value[i] === '\\' && value[i + 1] === 'n' && isUnescapedSlashNAt(value, i)) {
+      result += '\n'
+      i += 2
+      continue
+    }
+    result += value[i]
+    i++
+  }
+  return result
+}
+
+function isUnescapedSlashNAt(value: string, index: number): boolean {
+  let consecutiveSlashes = 0
+  for (let i = index - 1; i >= 0 && value[i] === '\\'; i--)
+    consecutiveSlashes++
+  return consecutiveSlashes % 2 === 0
 }

--- a/src/paratranz/converter/line-breaks.ts
+++ b/src/paratranz/converter/line-breaks.ts
@@ -9,6 +9,13 @@ const LINE_BREAK_PLACEHOLDER_FORMS = LINE_BREAK_FORMS.filter(
   (form): form is Exclude<LineBreakForm, 'LF'> => form !== 'LF',
 )
 const LINE_BREAK_FORM_SET = new Set<LineBreakForm>(LINE_BREAK_FORMS)
+// ParaTranz lowercases HTML-like tags inside a string item's `context`
+// (e.g. `<BR>` is rewritten to `<br>` on the server side), which would
+// otherwise collapse the `<BR>` and `<br>` forms after a round trip.
+// To preserve the original case we encode `<BR>` with a `-UP` suffix
+// before writing the marker; the suffix is plain text and is left
+// intact by ParaTranz, so `decodeLineBreakContextValue` can recover
+// the original form on read-back.
 const LINE_BREAK_CONTEXT_VALUES: Record<LineBreakForm, string> = {
   '<BR>': '<BR>-UP',
   '<br>': '<br>',
@@ -196,6 +203,9 @@ function allowedLineBreakForm(
 }
 
 function decodeLineBreakContextValue(value: string): LineBreakForm | undefined {
+  // ParaTranz only lowercases the `<BR>` portion of the marker, the
+  // `-UP` suffix is plain text and is kept as-is. Accept both the
+  // original `<BR>-UP` we wrote and the round-tripped `<br>-UP`.
   if (value === '<BR>-UP' || value === '<br>-UP')
     return '<BR>'
 

--- a/src/paratranz/converter/rules.ts
+++ b/src/paratranz/converter/rules.ts
@@ -1,7 +1,5 @@
 import type { LineBreakForm } from './line-breaks.ts'
 import type { Language } from '~/filetypes/language.ts'
-import { dirname } from 'node:path'
-import * as settings from '~/settings.ts'
 import { toUnicode } from '~/utils/unicode.ts'
 import { restoreLineBreaks } from './line-breaks.ts'
 
@@ -37,14 +35,6 @@ export class ScriptLineBreakRule implements LineBreakRule {
   }
 }
 
-export class QuestLineBreakRule implements LineBreakRule {
-  match = (relpath: string): boolean => {
-    return relpath.startsWith(dirname(settings.DEFAULT_QUESTS_LANG_TARGET_REL_PATH))
-  }
-
-  fallbackForm: LineBreakForm = '%n'
-}
-
 export class GTLangLineBreakRule implements LineBreakRule {
   match = (relpath: string): boolean => {
     return relpath.endsWith('GregTech.lang')
@@ -56,7 +46,6 @@ export class GTLangLineBreakRule implements LineBreakRule {
 export class LineBreakRules {
   private static readonly all: LineBreakRule[] = [
     new ScriptLineBreakRule(),
-    new QuestLineBreakRule(),
     new GTLangLineBreakRule(),
   ]
 

--- a/src/paratranz/types.ts
+++ b/src/paratranz/types.ts
@@ -1,5 +1,6 @@
 import { z } from 'zod'
 import { TARGET_LANGUAGES } from '~/filetypes/language.ts'
+import { log } from '~/log'
 
 export const FileSchema = z.object({
   id: z.number(),
@@ -42,6 +43,7 @@ export const FileExtraSchema = z.object({
   enUsRelpath: z.string().nullish(),
   targetRelpath: z.string().optional(),
 }).catchall(z.unknown()).transform((data) => {
+  const l = log.withTag('FileExtraSchema.transform')
   const { targetRelpath: inputTargetRelpath, enUsRelpath: inputEnUsRelpath, ...rest } = data
   let targetRelpath = inputTargetRelpath
   let enUsRelpath = inputEnUsRelpath
@@ -62,7 +64,7 @@ export const FileExtraSchema = z.object({
         targetRelpath = (rest as any)[legacyKey]
       }
       delete (rest as any)[legacyKey]
-      console.warn(`FileExtra.${legacyKey} is deprecated, use FileExtra.targetRelpath instead`)
+      l.warn(`FileExtra.${legacyKey} is deprecated, use FileExtra.targetRelpath instead`)
     }
   }
 

--- a/tests/paratranz/converter-line-breaks.test.ts
+++ b/tests/paratranz/converter-line-breaks.test.ts
@@ -4,6 +4,7 @@ import { FiletypeLang, Languages } from '~/filetypes/index.ts'
 import {
   collectLineBreakFormsFromContexts,
   LINE_BREAK_FORMS,
+  lineBreakOptionsForKey,
   normalizeLineBreaks,
   resolveLineBreakForm,
   restoreLineBreaks,
@@ -26,11 +27,22 @@ describe('line break conversion helpers', () => {
     expect(sniffLineBreak('a[br]b')).toBe('[br]')
     expect(sniffLineBreak('a\\\\nb')).toBe('\\\\n')
     expect(sniffLineBreak('a\\nb')).toBe('\\n')
-    expect(sniffLineBreak('a%nb')).toBe('%n')
+    expect(sniffLineBreak('a\\\\\\nb')).toBe('\\\\n')
+    expect(sniffLineBreak('a%nb')).toBeUndefined()
+    expect(sniffLineBreak('a%nb', { allowPercentN: true })).toBe('%n')
+    expect(sniffLineBreak('a%%nb', { allowPercentN: true })).toBeUndefined()
+    expect(sniffLineBreak('a%%%nb', { allowPercentN: true })).toBe('%n')
+    expect(sniffLineBreak(String.raw`a\\\nb`)).toBe('\\\\n')
     expect(sniffLineBreak('a\nb')).toBe('LF')
 
-    for (const value of ['a<BR>b', 'a<br>b', 'a[br]b', 'a\\\\nb', 'a\\nb', 'a%nb', 'a\nb'])
+    for (const value of ['a<BR>b', 'a<br>b', 'a[br]b', 'a\\\\nb', 'a\\nb', 'a\nb'])
       expect(normalizeLineBreaks(value)).toBe('a\nb')
+    expect(normalizeLineBreaks('a%nb')).toBe('a%nb')
+    expect(normalizeLineBreaks('a%nb', { allowPercentN: true })).toBe('a\nb')
+    expect(normalizeLineBreaks('a%%nb', { allowPercentN: true })).toBe('a%%nb')
+    expect(normalizeLineBreaks('a%%%nb', { allowPercentN: true })).toBe('a%%\nb')
+    expect(normalizeLineBreaks('a\\\\\\nb')).toBe('a\\\nb')
+    expect(normalizeLineBreaks(String.raw`a\\\nb`)).toBe('a\\\nb')
 
     expect(restoreLineBreaks('a\nb', '<BR>')).toBe('a<BR>b')
     expect(restoreLineBreaks('a\nb', '<br>')).toBe('a<br>b')
@@ -46,11 +58,30 @@ describe('line break conversion helpers', () => {
     expect(resolveLineBreakForm({ default: '\\n', entries: {} }, 'lang|foo.research.page.1', undefined)).toBe('<BR>')
   })
 
-  it('reads context markers', () => {
+  it('reads encoded context markers and current raw markers', () => {
     const forms = collectLineBreakFormsFromContexts([
+      { key: 'upper', context: '@gtnh-line-break-form=<BR>-UP' },
+      { key: 'upperReturnedFromParatranz', context: '@gtnh-line-break-form=<br>-UP' },
+      { key: 'lower', context: '@gtnh-line-break-form=<br>' },
       { key: 'current', context: '@gtnh-line-break-form=[br]' },
     ])
+    expect(forms.entries.upper).toBe('<BR>')
+    expect(forms.entries.upperReturnedFromParatranz).toBe('<BR>')
+    expect(forms.entries.lower).toBe('<br>')
     expect(forms.entries.current).toBe('[br]')
+  })
+
+  it('enables percent-n only for betterquesting.quest keys', () => {
+    expect(lineBreakOptionsForKey('foo.bar').allowPercentN).toBe(false)
+    expect(lineBreakOptionsForKey('betterquesting.quest.42').allowPercentN).toBe(true)
+    expect(lineBreakOptionsForKey('BetterQuesting.Quest.42').allowPercentN).toBe(true)
+
+    expect(collectLineBreakFormsFromContexts([
+      { key: 'current', context: '@gtnh-line-break-form=%n' },
+    ]).entries.current).toBeUndefined()
+    expect(collectLineBreakFormsFromContexts([
+      { key: 'betterquesting.quest.current', context: '@gtnh-line-break-form=%n' },
+    ]).entries['betterquesting.quest.current']).toBe('%n')
   })
 })
 
@@ -66,8 +97,7 @@ describe('Converter entry-level line break handling', () => {
         'b=one<BR>two',
         'c=one<br>two',
         'd=one[br]two',
-        'e=one%ntwo',
-        'f=one\\\\ntwo',
+        'e=one\\\\ntwo',
       ].join('\n'),
       Languages.en_US,
     )
@@ -94,17 +124,15 @@ describe('Converter entry-level line break handling', () => {
       'one\ntwo',
       'one\ntwo',
       'one\ntwo',
-      'one\ntwo',
     ])
     expect((uploaded.fileExtra as any).newlines).toBeUndefined()
     expect((uploaded.fileExtra as any).enUsRelpath).toBeUndefined()
     expect((uploaded.fileExtra as any).targetRelpath).toBeUndefined()
     expect(uploaded.stringItems.map(item => item.context)).toEqual([
       '@gtnh-line-break-form=\\n',
-      '@gtnh-line-break-form=<BR>',
+      '@gtnh-line-break-form=<BR>-UP',
       '@gtnh-line-break-form=<br>',
       '@gtnh-line-break-form=[br]',
-      '@gtnh-line-break-form=%n',
       '@gtnh-line-break-form=\\\\n',
     ])
     expect(uploaded.stringItems.every(item => !item.context?.includes('one'))).toBe(true)
@@ -121,21 +149,98 @@ describe('Converter entry-level line break handling', () => {
       'b=甲<BR>乙',
       'c=甲<br>乙',
       'd=甲[br]乙',
-      'e=甲%n乙',
-      'f=甲\\\\n乙',
+      'e=甲\\\\n乙',
     ].join('\n'))
   })
 
-  it('recovers entry-level forms from original content when context is absent', async () => {
+  it('uses percent-n only for betterquesting.quest keys', async () => {
     setupEnv()
     const { Converter } = await import('~/paratranz/converter/index.ts')
 
     const file = new FiletypeLang(
       'config/txloader/load/example/lang/en_US.lang',
       [
-        'a=one\\ntwo',
-        'b=one<BR>two',
+        'betterquesting.quest.1=one%ntwo',
+        'a=one%ntwo',
       ].join('\n'),
+      Languages.en_US,
+    )
+
+    const cache: any = {
+      get: () => undefined,
+      set: () => {},
+    }
+    const uploadClient: any = {
+      findFileIdByName: async () => undefined,
+    }
+    const converter = new Converter(uploadClient, cache, Languages.zh_CN)
+    const uploaded = await converter.toParatranzFile(file)
+
+    expect(uploaded.stringItems[0]!.key).toBe('lang|betterquesting.quest.1')
+    expect(uploaded.stringItems[0]!.original).toBe('one\ntwo')
+    expect(uploaded.stringItems[0]!.context).toBe('@gtnh-line-break-form=%n')
+    expect(uploaded.stringItems[1]!.key).toBe('lang|a')
+    expect(uploaded.stringItems[1]!.original).toBe('one%ntwo')
+    expect(uploaded.stringItems[1]!.context).toBeUndefined()
+
+    const downloadClient: any = {
+      getFile: async () => ({
+        id: 1,
+        name: uploaded.fileName,
+        modifiedAt: null,
+        extra: uploaded.fileExtra,
+      }),
+      getStrings: async () => uploaded.stringItems.map(item => ({
+        ...item,
+        translation: '甲\n乙',
+      })),
+    }
+    const downloadConverter = new Converter(downloadClient, cache, Languages.zh_CN)
+    const downloaded = await downloadConverter.toTranslationFile({
+      id: 1,
+      name: uploaded.fileName,
+      modifiedAt: null,
+      extra: uploaded.fileExtra,
+    })
+
+    expect(downloaded.content).toBe([
+      'betterquesting.quest.1=甲%n乙',
+      'a=甲\\n乙',
+    ].join('\n'))
+  })
+
+  it('uses fallback line break context when original has no line break', async () => {
+    setupEnv()
+    const { Converter } = await import('~/paratranz/converter/index.ts')
+
+    const file = new FiletypeLang(
+      'GregTech.lang',
+      'a=plain',
+      Languages.en_US,
+    )
+
+    const cache: any = {
+      get: () => undefined,
+      set: () => {},
+    }
+    const uploadClient: any = {
+      findFileIdByName: async () => undefined,
+    }
+    const converter = new Converter(uploadClient, cache, Languages.zh_CN)
+    const uploaded = await converter.toParatranzFile(file)
+
+    expect(uploaded.stringItems[0]!.original).toBe('plain')
+    expect(uploaded.stringItems[0]!.context).toBe('@gtnh-line-break-form=<BR>-UP')
+    expect(uploaded.stringItems[0]!.context).not.toContain('a=plain')
+  })
+
+  it('uses context markers instead of inferring line breaks from fileExtra original', async () => {
+    setupEnv()
+    const { Converter } = await import('~/paratranz/converter/index.ts')
+
+    const file = new FiletypeLang(
+      'config/txloader/load/example/lang/en_US.lang',
+      'a=one<BR>two',
       Languages.en_US,
     )
 
@@ -148,12 +253,12 @@ describe('Converter entry-level line break handling', () => {
     }
     const uploadConverter = new Converter(uploadClient, cache, Languages.zh_CN)
     const uploaded = await uploadConverter.toParatranzFile(file)
-    const legacyStringItems = uploaded.stringItems.map(({ context: _, ...item }) => item)
 
     const downloadClient: any = {
       getFile: async () => ({ id: 1, name: uploaded.fileName, modifiedAt: null, extra: uploaded.fileExtra }),
-      getStrings: async () => legacyStringItems.map(item => ({
+      getStrings: async () => uploaded.stringItems.map(item => ({
         ...item,
+        context: '@gtnh-line-break-form=<br>',
         translation: '甲\n乙',
       })),
     }
@@ -166,9 +271,6 @@ describe('Converter entry-level line break handling', () => {
       extra: uploaded.fileExtra,
     })
 
-    expect(downloaded.content).toBe([
-      'a=甲\\n乙',
-      'b=甲<BR>乙',
-    ].join('\n'))
+    expect(downloaded.content).toBe('a=甲<br>乙')
   })
 })


### PR DESCRIPTION
- 修复\<BR\>被pt转换为\<br\>的识别问题。现在\<BR\>写入context时是\<BR\>-up，写回时也能识别\<br\>-up。
- 修复 %n 识别逻辑：%%n 不再被误判为换行，%%%n 可正确识别最后的 %n（按奇偶转义规则处理）。
- 将 \n 的识别与归一化也改为奇偶转义逻辑，避免转义场景误替换。
- 将 %n 启用条件从“按文件路径包含 betterquesting”调整为“按 key 包含 betterquesting.quest”，支持同文件内按条目精确控制。
- 将 FileExtra 旧字段弃用提示从 console.warn 改为统一 log 日志体系（带 tag）。