### PR TITLE
fix: update quest book paths for txloader forceload

### DIFF
--- a/src/settings.ts
+++ b/src/settings.ts
@@ -7,13 +7,13 @@ export const TARGET_LANG = parseLanguage(env.TARGET_LANG ?? Languages.zh_CN)
 export const GTNH_REPO = env.GTNH_REPO ?? 'GTNewHorizons/GT-New-Horizons-Modpack'
 
 export const DEFAULT_QUESTS_LANG_TEMPLATE_REL_PATH = env.DEFAULT_QUESTS_LANG_TEMPLATE_REL_PATH
-  ?? 'config/txloader/load/betterquesting/lang/template.lang'
+  ?? 'config/txloader/forceload/betterquesting/lang/template.lang'
 
 export const DEFAULT_QUESTS_LANG_EN_US_REL_PATH = env.DEFAULT_QUESTS_LANG_EN_US_REL_PATH
-  ?? 'config/txloader/load/betterquesting/lang/en_US.lang'
+  ?? 'config/txloader/forceload/betterquesting/lang/en_US.lang'
 
 export const DEFAULT_QUESTS_LANG_TARGET_REL_PATH = env.DEFAULT_QUESTS_LANG_TARGET_REL_PATH
-  ?? `config/txloader/load/betterquesting/lang/${TARGET_LANG}.lang`
+  ?? `config/txloader/forceload/betterquesting/lang/${TARGET_LANG}.lang`
 
 export const GT_LANG_EN_US_REL_PATH = 'GregTech_US.lang'
 export const GT_LANG_TARGET_REL_PATH = 'GregTech.lang'


### PR DESCRIPTION
## What

GTNH moved the DefaultQuests (quest book) lang in the modpack:

- **old:** `config/txloader/load/betterquesting/lang/` — now **404**
- **new:** `config/txloader/forceload/betterquesting/lang/` — has `template.lang`

Verified against `GTNewHorizons/GT-New-Horizons-Modpack@master`:

```
$ curl -s -o /dev/null -w '%{http_code}' .../forceload/betterquesting/lang/template.lang  -> 200
$ curl -s -o /dev/null -w '%{http_code}' .../load/betterquesting/lang/template.lang       -> 404
```

So `to-paratranz:quest-book` (which fetches `DEFAULT_QUESTS_LANG_TEMPLATE_REL_PATH` from the modpack via raw.githubusercontent) now throws `Failed to get quest book file`, breaking the quest-book sync.

## Change

Point the three quest-book path defaults in `src/settings.ts` at the new `forceload` location (`load` → `forceload`):

- `DEFAULT_QUESTS_LANG_TEMPLATE_REL_PATH`
- `DEFAULT_QUESTS_LANG_EN_US_REL_PATH`
- `DEFAULT_QUESTS_LANG_TARGET_REL_PATH`

All three move together to keep the upload filename and the `from-paratranz` filter consistent. They remain overridable via the same-named env vars.
